### PR TITLE
Fix class FilterableQuerySetMixin for accepting multiple-item-type arguments

### DIFF
--- a/pubg_python/mixins.py
+++ b/pubg_python/mixins.py
@@ -81,11 +81,24 @@ class FilterableQuerySetMixin:
         'game_mode': 'gameMode',
     }
 
+    FILTER_MULTIPLES = (
+        'player_ids',
+        'player_names',
+    )
+
     @invalidates_cache
     def filter(self, **kwargs):
         for kw in kwargs:
             if kw not in self.FILTER_MAPPING:
                 raise InvalidFilterError('Invalid filter')
+
+            if kw in self.FILTER_MULTIPLES:
+                if not isinstance(kwargs[kw], list):
+                    raise InvalidFilterError('Invalid filter value')
+                value = ','.join(kwargs[kw])
+            else:
+                value = kwargs[kw]
+
             self.endpoint.args[
-                'filter[{}]'.format(self.FILTER_MAPPING[kw])] = kwargs[kw]
+                'filter[{}]'.format(self.FILTER_MAPPING[kw])] = value
         return self


### PR DESCRIPTION
Hi Ramon,

```python
players = api.players().filter(player_names=['Name1', 'Name2', 'Name3'])

for player in players:
    print(player.name)

# ISSUE: It prints only one line 'Name1'
```

I just ran across something to fix when calling method `.filter()` in class `FilterableQuerySetMixin`. It doesn't retrieve a list of players filtering by names or ids. It returns only one player first named in input list. So I added class constant `FILTER_MULTIPLES` and fixed related code.

Thank you for sharing nice python wrapper for PUBG API.