### PR TITLE
Add pc-jp server

### DIFF
--- a/pubg_python/domain/base.py
+++ b/pubg_python/domain/base.py
@@ -5,11 +5,12 @@ class Shard(Enum):
     PC_AS = 'pc-as'  # Asia
     PC_EU = 'pc-eu'  # Europe
     PC_KAKAO = 'pc-kakao'  # Kakaogames server (Korea only)
-    PC_KRJP = 'pc-krjp'  # Korea/Japan
+    PC_KRJP = 'pc-krjp'  # Korea
     PC_NA = 'pc-na'  # North America
     PC_OC = 'pc-oc'  # Oceania
     PC_SA = 'pc-sa'  # South and Central America
     PC_SEA = 'pc-sea'  # South East Asia
+    PC_JP = 'pc-jp'  # Japan
     XBOX_AS = 'xbox-as'  # Asia
     XBOX_EU = 'xbox-eu'  # Europe
     XBOX_NA = 'xbox-na'  # North America


### PR DESCRIPTION
I added the pc-jp server to Shard.
This is a newly added Region on March 27.

Source: [Making Requests - pubg 1.0 documentation](https://documentation.playbattlegrounds.com/en/making-requests.html#regions)