### PR TITLE
Modify LogVehicle object's variable

### DIFF
--- a/pubg_python/domain/telemetry/events.py
+++ b/pubg_python/domain/telemetry/events.py
@@ -134,8 +134,7 @@ class LogVehicle(Event):
     def from_dict(self):
         super().from_dict()
         self.character = objects.Character(self._data.get('character', {}))
-        self.item = objects.Item(self._data.get('item', {}))
-
+        self.vehicle = objects.Vehicle(self._data.get('vehicle', {}))
 
 class LogVehicleRide(LogVehicle):
     pass


### PR DESCRIPTION
LogVehicleRide and LogVehicleLeave objects have Vehicle instead of Item.
(https://documentation.playbattlegrounds.com/en/telemetry-events.html#logvehicleride)