### PR TITLE
modify typo attacker_type -> attack_type

### DIFF
--- a/pubg_python/domain/telemetry/events.py
+++ b/pubg_python/domain/telemetry/events.py
@@ -54,7 +54,7 @@ class LogPlayerAttack(Event):
         super().from_dict()
         self.attack_id = self._data.get('attackId')
         self.attacker = objects.Character(self._data.get('attacker', {}))
-        self.attacker_type = self._data.get('attackerType')
+        self.attack_type = self._data.get('attackType')
         self.weapon = objects.Item(self._data.get('weapon', {}))
         self.vehicle = objects.Vehicle(self._data.get('vehicle', {}))
 


### PR DESCRIPTION
For LogPlayerAttack telemetry event, attacker_type should be attack_type based on the documentation: https://documentation.playbattlegrounds.com/en/telemetry-events.html#logplayerattack

Thank you