### PR TITLE
LogWheelDestroy, LogPlayerMakeGroggy, LogPlayerRevive

### DIFF
--- a/pubg_python/domain/telemetry/events.py
+++ b/pubg_python/domain/telemetry/events.py
@@ -235,4 +235,28 @@ class LogArmorDestroy(Event):
         self.damage_reason = self._data.get('damageReason')
 
 class LogWheelDestroy(Event):
-    pass
+    def from_dict(self):
+        super().from_dict()
+        self.attack_id = self._data.get('attackId')
+        self.attacker = objects.Character(self._data.get('attacker', {}))
+        self.vehicle = objects.Vehicle(self._data.get('vehicle', {}))
+        self.damage_type_category = self._data.get('damageTypeCategory')
+        self.damage_causer_name = self._data.get('damageCauserName')
+
+class LogPlayerMakeGroggy(Event):
+    def from_dict(self):
+        super().from_dict()
+        self.attack_id = self._data.get('attackId')
+        self.attacker = objects.Character(self._data.get('attacker', {}))
+        self.victim = objects.Character(self._data.get('victim', {}))
+        self.damage_type_category = self._data.get('damageTypeCategory')
+        self.damage_causer_name = self._data.get('damageCauserName')
+        self.distance = self._data.get('distance')
+        self.is_attacker_in_vehicle = self._data.get('isAttackerInVehicle')
+        self.dbno_id = self._data.get('dBNOId')
+
+class LogPlayerRevive(Event):
+    def from_dict(self):
+        super().from_dict()
+        self.reviver = objects.Character(self._data.get('reviver', {}))
+        self.victim = objects.Character(self._data.get('victim', {}))

--- a/pubg_python/domain/telemetry/events.py
+++ b/pubg_python/domain/telemetry/events.py
@@ -233,3 +233,6 @@ class LogArmorDestroy(Event):
         self.item = objects.Item(self._data.get('item', {}))
         self.victim = objects.Character(self._data.get('victim', {}))
         self.damage_reason = self._data.get('damageReason')
+
+class LogWheelDestroy(Event):
+    pass


### PR DESCRIPTION
When i tried to get telemetry data of the new map "Sanhok", got `KeyError`:

```
  File "./pubglib/datahandler.py", line 229, in getTelemetry
    telemetry = api.telemetry(asset.url)
  File "/usr/local/lib/python3.6/site-packages/pubg_python/base.py", line 52, in telemetry
    return Telemetry(data, url)
  File "/usr/local/lib/python3.6/site-packages/pubg_python/domain/telemetry/base.py", line 13, in __init__
    for event_data in self.generate_events_data(data)
  File "/usr/local/lib/python3.6/site-packages/pubg_python/domain/telemetry/base.py", line 13, in <listcomp>
    for event_data in self.generate_events_data(data)
  File "/usr/local/lib/python3.6/site-packages/pubg_python/domain/telemetry/events.py", line 18, in instance
    return globals()[data['_T']](data)
KeyError: 'LogWheelDestroy'
```
It seems that `LogWheelDestroy` in this moment undocumented telemetry event. So I added a function stub for it. Without this fix, the application does not work.