### PR TITLE
remove _V key. Change Log V1.5.0

### DIFF
--- a/pubg_python/domain/telemetry/events.py
+++ b/pubg_python/domain/telemetry/events.py
@@ -10,7 +10,6 @@ class Event:
     def from_dict(self):
         self.event = self._data['_T']
         self.timestamp = self._data['_D']
-        self.version = self._data['_V']
         self.common = objects.Common(self._data.get('common', {}))
 
     @staticmethod


### PR DESCRIPTION
https://documentation.playbattlegrounds.com/en/changelog/changelog.html


Deprecated:

player.attributes.createdAt
player.attributes.updatedAt
Bug Fixes:

participant.attributes.stats.timeSurvived – int -> number
participant.attributes.stats.longestKill – int -> number
Removed:

(any).common.mapName //available in LogMatchStart
(any).common.matchId //available in LogMatchDefinition
(any)._V
LogPlayerLogin.errorMessage
LogPlayerLogin.result