### PR TITLE
Add shard for pc tournament matches

### DIFF
--- a/pubg_python/domain/base.py
+++ b/pubg_python/domain/base.py
@@ -14,6 +14,7 @@ class Shard(Enum):
     PC_SEA = 'pc-sea'  # South East Asia
     PC_JP = 'pc-jp'  # Japan
     PC_RU = 'pc-ru'  # Russia
+    PC_TOURNAMENT = 'pc-tournament' # PC Tournaments Shard
     XBOX_AS = 'xbox-as'  # Asia
     XBOX_EU = 'xbox-eu'  # Europe
     XBOX_NA = 'xbox-na'  # North America


### PR DESCRIPTION
Per https://documentation.playbattlegrounds.com/en/making-requests.html if you want to query match information about tournaments you need to pass it the pc-tournament shard.