### PR TITLE
add damage causer name for player kill event

### DIFF
--- a/pubg_python/domain/telemetry/events.py
+++ b/pubg_python/domain/telemetry/events.py
@@ -87,6 +87,7 @@ class LogPlayerKill(Event):
         self.victim = objects.Character(self._data.get('victim', {}))
         self.damage_type_category = self._data.get('damageTypeCategory')
         self.damage_reason = self._data.get('damageReason')
+        self.damage_causer_name = self._data.get('damageCauserName')
         self.distance = self._data.get('distance')
 
 


### PR DESCRIPTION
It is a nice tool to query the data and thank you very much for developing this repo. 

Can't get weapon info directly from the kill event. Therefore I'd like to add one more field to it. I also see this field is included in `GroggyEvent`, so I'm pretty sure it will be useful to include in `KillEvent` as well.