### PR TITLE
add seasons api

### DIFF
--- a/pubg_python/base.py
+++ b/pubg_python/base.py
@@ -55,6 +55,10 @@ class PUBG:
     def samples(self):
         pass
 
+    @shardful_endpoint
+    def seasons(self):
+        pass
+
     @endpoint
     def tournaments(self):
         pass


### PR DESCRIPTION
As a updated change for #42 

Tests
```
>>> from pubg_python import PUBG, Shard
>>> api = PUBG('<api-key>', Shard.PC_NA)
>>> q = api.seasons()
>>> q.fetch()
>>> q._data
{'data': [{'type': 'season', 'id': 'division.bro.official.2017-beta', 'attributes': {'isOffseason': False, 'isCurrentSeason': False}},
...
```

One thing I don't quite understand and current code doesn't handle well is you can't do list(api.seasons). Because in `__iter__`,  'Season' key won't be able to find for globals() in Domain. I'm not sure why it was created in that way, or perhaps I was not calling it correctly.

Another question I had is I don't quite get the mechanism on `players()` where you can do `.filter(player_names = [])`, how is that implemented? However, for `seasons()`, such attribute is not quite needed, for the normal case will be getting seasons list and current seasons to further get match ids for a given season.

At least from _data I can get all the seasons and we can do other stuff from it. Let me know what you think or if you have any questions. Thanks!