### PR TITLE
Fix deserialization for nested items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.1 / 2019-09-02
+
+* Fix deserialization for nested items
+
 ## 0.10.0 / 2019-09-02
 
 * Sync domain classes/telemetry data with latest API changes (synced with V14.1.0)

--- a/pubg_python/domain/telemetry/objects.py
+++ b/pubg_python/domain/telemetry/objects.py
@@ -23,7 +23,8 @@ class BaseObject:
 class Object(BaseObject):
 
     def deserialize(self, data):
-        return data if isinstance(data, TelemetryData) else {}
+        # TODO: process nested objects as telemetry data
+        return data if isinstance(data, (TelemetryData, dict)) else {}
 
 
 class StringifiedObject(BaseObject):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name='pubg-python',
-    version='0.10.0',
+    version='0.10.1',
     description='A python wrapper for the PUBG developer API',
     long_description=read('README.md'),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Closes #52 

Nested items in telemetry data are not being identified as instances of `TelemetryData` so the deserialization was simply returning an empty object 👎 

This adds a quick fix to the deserialize logic allowing `dict` instances to be deserialized as well, until a proper fix (identifying nested items as TelemetryData) is done.