### PR TITLE
Switch to actual PUBG API domain

### DIFF
--- a/pubg_python/clients.py
+++ b/pubg_python/clients.py
@@ -36,7 +36,7 @@ class Client:
 
 class APIClient(Client):
 
-    BASE_URL = 'https://api.playbattlegrounds.com/'
+    BASE_URL = 'https://api.pubg.com/'
 
     def __init__(self, api_key):
         super().__init__()

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name='pubg-python',
-    version='0.11.1',
+    version='0.11.2',
     description='A python wrapper for the PUBG developer API',
     long_description=read('README.md'),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Set it to `https://api.pubg.com`
[Documentation](https://documentation.pubg.com/en/getting-started.html#the-url)