### PR TITLE
Fix on throwables

### DIFF
--- a/pubg_python/domain/telemetry/events.py
+++ b/pubg_python/domain/telemetry/events.py
@@ -79,6 +79,15 @@ class LogPlayerTakeDamage(Event):
         self.damage = self._data.get('damage')
         self.damage_causer_name = self._data.get('damageCauserName')
 
+class LogPlayerUseThrowable(Event):
+    
+    def from_dict(self):
+        super().from_dict()
+        self.attack_id = self._data.get('attackId')
+        self.fire_weapon_stack_count = self._data.get('fireWeaponStackCount')
+        self.attacker = objects.Character(self._data.get('attacker', {}))
+        self.attack_type = self._data.get('attackType')
+        self.weapon = objects.Item(self._data.get('weapon', {}))
 
 class LogPlayerKill(Event):
 

--- a/pubg_python/domain/telemetry/events.py
+++ b/pubg_python/domain/telemetry/events.py
@@ -79,6 +79,7 @@ class LogPlayerTakeDamage(Event):
         self.damage = self._data.get('damage')
         self.damage_causer_name = self._data.get('damageCauserName')
 
+
 class LogPlayerUseThrowable(Event):
     
     def from_dict(self):
@@ -88,6 +89,7 @@ class LogPlayerUseThrowable(Event):
         self.attacker = objects.Character(self._data.get('attacker', {}))
         self.attack_type = self._data.get('attackType')
         self.weapon = objects.Item(self._data.get('weapon', {}))
+
 
 class LogPlayerKill(Event):
 


### PR DESCRIPTION
There is a new event in the telemetry: [LogPlayerUseThrowable](https://documentation.pubg.com/en/telemetry-events.html#logplayerusethrowable) which was not added on the telemetry parser.